### PR TITLE
fix(types): correct Omit typing in ChainablePromiseElement

### DIFF
--- a/packages/webdriverio/src/types.ts
+++ b/packages/webdriverio/src/types.ts
@@ -69,6 +69,7 @@ interface ChainablePromiseBaseElement {
     getElement(): Promise<WebdriverIO.Element>
 }
 export interface ChainablePromiseElement extends
+    Promise<WebdriverIO.Element>,
     ChainablePromiseBaseElement,
     AsyncElementProto,
     Omit<WebdriverIO.Element, keyof ChainablePromiseBaseElement | keyof AsyncElementProto> {}
@@ -95,7 +96,9 @@ interface AsyncIterators<T> {
     entries(): AsyncIterableIterator<[number, WebdriverIO.Element]>;
 }
 
-export interface ChainablePromiseArray extends AsyncIterators<WebdriverIO.Element> {
+export interface ChainablePromiseArray extends
+    Promise<WebdriverIO.Element[]>,
+    AsyncIterators<WebdriverIO.Element> {
     [Symbol.asyncIterator](): AsyncIterableIterator<WebdriverIO.Element>
     [Symbol.iterator](): IterableIterator<WebdriverIO.Element>
 

--- a/tests/typings/webdriverio/async.ts
+++ b/tests/typings/webdriverio/async.ts
@@ -460,6 +460,10 @@ async function bar() {
         await browser.$('foo').$('bar').$$('loo').selector)
     expectType<WebdriverIO.Browser | WebdriverIO.Element | WebdriverIO.MultiRemoteBrowser>(
         await browser.$('foo').$('bar').$$('loo').parent)
+    expectType<Promise<WebdriverIO.Element>>(browser.$('foo'))
+    expectType<Promise<WebdriverIO.Element[]>>(browser.$$('foo'))
+    expectType<Promise<number>>(
+        browser.$('foo').$('bar').$$('loo').length)
 
     // promise chain API
     expectType<string>(
@@ -496,7 +500,9 @@ async function bar() {
     for await (const el of browser.$$('foo')) {
         expectType<WebdriverIO.Element>(el)
     }
+    expectType<Promise<number>>(browser.$$('foo').length)
     const panels = await browser.$$('foo')
+    expectType<WebdriverIO.ElementArray>(await browser.$$('foo'))
     for (const panel of panels) {
         await expect(panel).toHaveAttr('class', 'false')
     }
@@ -522,6 +528,7 @@ async function bar() {
     // getElement type check
     const singleChainedElement = await browser.$('foo').getElement()
     const singleElement = await singleChainedElement.getElement()
+    expectType<WebdriverIO.Element>(await browser.$('foo'))
     expectType<string>(singleElement.elementId)
     expectType<string>(singleElement.elementId)
     // @ts-expect-error


### PR DESCRIPTION
## Summary
- ensure `ChainablePromiseElement` and `ChainablePromiseArray` implement the `Promise` interface so chained calls continue to resolve correctly
- extend the typings test suite to cover awaiting of elements and direct access to chainable array `length`

## Testing
- pnpm compile:all:core
- pnpm compile:all:main
- pnpm test:typings:webdriverio *(fails: TypeScript declaration build for `@wdio/browserstack-service` rejects `Buffer`→`BlobPart` assignments, preventing d.ts generation)*

------
https://chatgpt.com/codex/tasks/task_e_68cab876d6a48326be398e419fe88fa4